### PR TITLE
feat: add persistence to favorite-drivers and saved-locations stores

### DIFF
--- a/src/store/favorite-drivers-store.ts
+++ b/src/store/favorite-drivers-store.ts
@@ -1,4 +1,6 @@
 import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 interface FavoriteDriversStore {
   favoriteDriverIds: string[];
@@ -8,36 +10,44 @@ interface FavoriteDriversStore {
   toggleFavorite: (driverId: string) => void;
 }
 
-export const useFavoriteDriversStore = create<FavoriteDriversStore>((set, get) => ({
-  favoriteDriverIds: [],
+export const useFavoriteDriversStore = create<FavoriteDriversStore>()(
+  persist(
+    (set, get) => ({
+      favoriteDriverIds: [],
 
-  addFavorite: (driverId) => {
-    set((state) => {
-      if (state.favoriteDriverIds.includes(driverId)) {
-        return state;
-      }
-      return {
-        favoriteDriverIds: [...state.favoriteDriverIds, driverId],
-      };
-    });
-  },
+      addFavorite: (driverId) => {
+        set((state) => {
+          if (state.favoriteDriverIds.includes(driverId)) {
+            return state;
+          }
+          return {
+            favoriteDriverIds: [...state.favoriteDriverIds, driverId],
+          };
+        });
+      },
 
-  removeFavorite: (driverId) => {
-    set((state) => ({
-      favoriteDriverIds: state.favoriteDriverIds.filter((id) => id !== driverId),
-    }));
-  },
+      removeFavorite: (driverId) => {
+        set((state) => ({
+          favoriteDriverIds: state.favoriteDriverIds.filter((id) => id !== driverId),
+        }));
+      },
 
-  isFavorite: (driverId) => {
-    return get().favoriteDriverIds.includes(driverId);
-  },
+      isFavorite: (driverId) => {
+        return get().favoriteDriverIds.includes(driverId);
+      },
 
-  toggleFavorite: (driverId) => {
-    const { isFavorite, addFavorite, removeFavorite } = get();
-    if (isFavorite(driverId)) {
-      removeFavorite(driverId);
-    } else {
-      addFavorite(driverId);
+      toggleFavorite: (driverId) => {
+        const { isFavorite, addFavorite, removeFavorite } = get();
+        if (isFavorite(driverId)) {
+          removeFavorite(driverId);
+        } else {
+          addFavorite(driverId);
+        }
+      },
+    }),
+    {
+      name: 'favorite-drivers-storage',
+      storage: createJSONStorage(() => AsyncStorage),
     }
-  },
-}));
+  )
+);

--- a/src/store/saved-locations-store.ts
+++ b/src/store/saved-locations-store.ts
@@ -1,4 +1,6 @@
 import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 export interface SavedLocation {
   id: string;
@@ -23,43 +25,51 @@ interface SavedLocationsStore {
   getWorkLocation: () => SavedLocation | undefined;
 }
 
-export const useSavedLocationsStore = create<SavedLocationsStore>((set, get) => ({
-  locations: [],
+export const useSavedLocationsStore = create<SavedLocationsStore>()(
+  persist(
+    (set, get) => ({
+      locations: [],
 
-  addLocation: (location) => {
-    const newLocation: SavedLocation = {
-      ...location,
-      id: `location-${Date.now()}`,
-      createdAt: new Date().toISOString(),
-    };
-    set((state) => ({
-      locations: [newLocation, ...state.locations],
-    }));
-  },
+      addLocation: (location) => {
+        const newLocation: SavedLocation = {
+          ...location,
+          id: `location-${Date.now()}`,
+          createdAt: new Date().toISOString(),
+        };
+        set((state) => ({
+          locations: [newLocation, ...state.locations],
+        }));
+      },
 
-  updateLocation: (id, updates) => {
-    set((state) => ({
-      locations: state.locations.map((location) =>
-        location.id === id ? { ...location, ...updates } : location
-      ),
-    }));
-  },
+      updateLocation: (id, updates) => {
+        set((state) => ({
+          locations: state.locations.map((location) =>
+            location.id === id ? { ...location, ...updates } : location
+          ),
+        }));
+      },
 
-  removeLocation: (id) => {
-    set((state) => ({
-      locations: state.locations.filter((location) => location.id !== id),
-    }));
-  },
+      removeLocation: (id) => {
+        set((state) => ({
+          locations: state.locations.filter((location) => location.id !== id),
+        }));
+      },
 
-  getLocationByLabel: (label) => {
-    return get().locations.find((location) => location.label === label);
-  },
+      getLocationByLabel: (label) => {
+        return get().locations.find((location) => location.label === label);
+      },
 
-  getHomeLocation: () => {
-    return get().locations.find((location) => location.label === 'Home');
-  },
+      getHomeLocation: () => {
+        return get().locations.find((location) => location.label === 'Home');
+      },
 
-  getWorkLocation: () => {
-    return get().locations.find((location) => location.label === 'Work');
-  },
-}));
+      getWorkLocation: () => {
+        return get().locations.find((location) => location.label === 'Work');
+      },
+    }),
+    {
+      name: 'saved-locations-storage',
+      storage: createJSONStorage(() => AsyncStorage),
+    }
+  )
+);


### PR DESCRIPTION
## Summary
Add Zustand persist middleware with AsyncStorage to stores that should retain user data:
- **favorite-drivers-store**: User's favorited drivers persist across app restarts
- **saved-locations-store**: User's saved locations (Home, Work, custom) persist

## Closes
N/A - Internal improvement from codebase audit

## Screenshots
N/A - No visual changes, data persistence happens transparently

## How to Test
1. Run the app
2. Add a driver to favorites (star icon on driver profile)
3. Add a saved location (Profile > Saved Locations)
4. Force close the app completely
5. Reopen the app
6. Verify favorites and saved locations are still there

## Risk/Impact
- **Risk**: Low - Uses same proven pattern as trip-history-store and auth-store
- **Impact**: Improved UX - users don't lose their favorites/saved locations on restart

## Checklist
- [x] Code follows project style guidelines
- [x] No new TypeScript errors introduced  
- [x] Follows existing persist pattern in codebase
- [x] Uses AsyncStorage (same as other persisted stores)

## Additional Notes
- Stores NOT persisted (intentionally):
  - `route-store`: Temporary session data, should reset on restart
  - `location-store`: Current location always fetched fresh from device

🤖 Generated with [Claude Code](https://claude.com/claude-code)